### PR TITLE
Revise README to enhance clarity and detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,94 @@
-# cosrib
+# Coscribe (cosrib)
 
-Öffentliches Repository der Organisation **[cosrib](https://github.com/cosrib)** – **ohne Quellcode**.
+**Coscribe** is a web product for **independent freelancers** who sell services—consulting, design, development, marketing, and similar work—and who want a **clearer workflow** for **cold outreach** and **follow-ups**, instead of juggling a generic chat, an inbox, and scattered notes with no single “finished” result.
 
----
-
-## Was du hier siehst
-
-- **Kein vollständiger Quellcode** – aktive Entwicklung läuft **nicht** in diesem Repo.
-- **Issues, Diskussionen oder ältere Einträge** können aus Gründen der Transparenz oder Historie weiter existieren.
-
-## Was du hier nicht siehst
-
-- Kein aktuelles App-Repository zum Klonen oder Forken.
-- Keine Build-Anleitung oder interne Dokumentation – die gehört in die private Entwicklung.
-
-## Produkt (Kurz)
-
-**Coscribe** – Unterstützung für Freelancer bei **E-Mail-Akquise**, **Follow-ups** und später CRM-orientierten Bausteinen. Details veröffentlichen wir über die offiziellen Kanäle des Produkts, nicht über dieses Repository.
-
-## Kontakt
-
-Sachliche Anfragen bitte über die **offiziellen Kanäle** der Organisation bzw. des Produkts (Website, E-Mail), nicht über Issues in diesem Repo, sofern nicht ausdrücklich dafür vorgesehen.
+This **public repository** is here for **transparency**: what we are building and why. It does **not** include our application source code. Development happens in **private** repositories.
 
 ---
 
-*Letzte Aktualisierung der README: Hinweis „nur öffentliche Transparenz, Code privat“.*
+## The problem we focus on
+
+Many freelancers:
+
+- Spend time **context-switching** between AI chats, email, and docs without a **single deliverable** they can copy, save, and reuse for the next campaign.
+- **Repeat the same story** every time—who they are, how they sound, what they offer, what to avoid.
+- **Under-use follow-ups**, even though polite, well-timed reminders often matter more than the first message.
+
+General-purpose assistants can draft text, but they rarely anchor the work as a **repeatable job** with a **visible outcome**: one structured outreach package you can stand behind.
+
+---
+
+## What Coscribe is
+
+- **Job-first, not chat-first**  
+  Flows like starting a **new campaign** aim at a **concrete outcome**—for example a first email, numbered follow-ups, and a short pre-send checklist—rather than an endless back-and-forth as the main experience.
+
+- **The deliverable in the center**  
+  The **artifact** (emails, follow-ups, checklist) is meant to stay **easy to read and copy** in the product. Any conversational help is there to **support** that outcome, not to replace it.
+
+- **Durable freelancer context**  
+  We care about **saving** tone, constraints, and offer context so people are not retyping long prompts for every new outreach. The exact feature set will evolve with releases.
+
+- **Honest positioning**  
+  We care about **trust** and **verification**—for example, any automated research hints should be **checked before you send**. We do **not** promise fixed reply rates or a guaranteed number of leads.
+
+- **Roadmap: control over AI cost**  
+  We are oriented toward a model where **you** keep **control** over provider and cost (for example bringing your own API keys where models are used). Details ship when the product is ready.
+
+---
+
+## What this repo is for
+
+| | |
+|---|---|
+| **Transparency** | Explain the product direction in plain language. |
+| **Issues** | High-level feedback, README corrections, and **security** coordination—see below. |
+| **History** | Older stars or issues may remain; they do **not** mean this repo contains open-source app code. |
+
+## What this repo is **not**
+
+- Not a place to **clone or run** the application.
+- Not our **internal delivery board**; detailed execution lives in private development.
+- Not a channel for **secrets**, credentials, or personal customer data.
+
+---
+
+## Product directions we talk about publicly
+
+These are **themes**, not promises or dates:
+
+- A **“my business”** area—portfolio, proof, style, pricing hints in one place.
+- **Follow-up sequences** with sensible timing, not only static copy.
+- A **lightweight pipeline** (e.g. draft vs sent vs waiting) without building a full enterprise CRM.
+- **Research assistance** from a URL to reduce blank-page friction—always **verify before sending**.
+- **Export / ready-to-send** flows so copying into email clients is less painful.
+
+---
+
+## Security
+
+If you think you have found a **security vulnerability**, please **do not** post exploit details in a public issue. Use GitHub **Security advisories** for this repository if they are enabled, or reach the team through an **official private contact** published on the product or organization site.
+
+---
+
+## Contributing code here
+
+We do **not** merge **application source code** through this public repository. If that ever changes, we will say so on official channels.
+
+You **can** open issues about **this README** (typos, unclear wording) or use the templates we provide for **feedback** and **documentation**.
+
+---
+
+## Trademarks
+
+**Coscribe** and **cosrib** are used to identify the product and organization. Other names belong to their respective owners.
+
+---
+
+## Contact
+
+For **product**, **press**, or **partnership** questions, please use the **official channels** listed by the **cosrib** organization or **Coscribe**. Do not send secrets or sensitive personal data through GitHub issues.
+
+---
+
+*This README is intentionally high-level. It does not describe internals, stack details, or anything that would belong in a private engineering repository.*


### PR DESCRIPTION
Expanded the README to clarify the purpose of Coscribe and its functionalities for freelancers. Added sections on product direction, repo transparency, and security guidelines.